### PR TITLE
feat(controls): adding different styles props to toggle controls

### DIFF
--- a/src/Controls/BtnTemplate.tsx
+++ b/src/Controls/BtnTemplate.tsx
@@ -13,6 +13,7 @@ const BtnTemplate = (props: BtnTemplateInterface) => {
   const { onClick, name, disabled, style } = props
   const { styleProps } = useContext(PropsContext)
   const { theme, BtnTemplateStyles, iconSize, customIcon } = styleProps || {}
+  console.log('dentro del btn template', styleProps)
   return (
     <div
       style={{

--- a/src/Controls/BtnTemplate.tsx
+++ b/src/Controls/BtnTemplate.tsx
@@ -13,7 +13,7 @@ const BtnTemplate = (props: BtnTemplateInterface) => {
   const { onClick, name, disabled, style } = props
   const { styleProps } = useContext(PropsContext)
   const { theme, BtnTemplateStyles, iconSize, customIcon } = styleProps || {}
-  console.log('dentro del btn template', styleProps)
+
   return (
     <div
       style={{

--- a/src/Controls/Local/FullScreen.tsx
+++ b/src/Controls/Local/FullScreen.tsx
@@ -5,7 +5,7 @@ import BtnTemplate from '../BtnTemplate'
 function FullScreen() {
   const { styleProps, callbacks } = useContext(PropsContext)
   const { localBtnStyles } = styleProps || {}
-  const { fullScreen } = localBtnStyles || {}
+  const { fullScreen, normalScreen } = localBtnStyles || {}
   const [action, setAction] = useState('fullScreen')
 
   const onClick = () => {
@@ -21,7 +21,13 @@ function FullScreen() {
 
   return (
     <div>
-      <BtnTemplate style={fullScreen} name='fullScreen' onClick={onClick} />
+      <BtnTemplate
+        style={
+          action === 'fullScreen' ? fullScreen : normalScreen || fullScreen
+        }
+        name='fullScreen'
+        onClick={onClick}
+      />
     </div>
   )
 }

--- a/src/Controls/Local/LocalAudioMute.tsx
+++ b/src/Controls/Local/LocalAudioMute.tsx
@@ -11,7 +11,7 @@ function LocalAudioMute() {
   const { muteLocalAudio, unmuteLocalAudio } = localBtnStyles || {}
   const { dispatch, localAudioTrack } = useContext(RtcContext)
   const local = useContext(LocalContext)
-  console.log('mute', muteLocalAudio, unmuteLocalAudio)
+  console.log('****mute****', muteLocalAudio, unmuteLocalAudio)
   console.log(local.hasAudio === ToggleState.enabled)
   console.log(
     local.hasAudio === ToggleState.enabled

--- a/src/Controls/Local/LocalAudioMute.tsx
+++ b/src/Controls/Local/LocalAudioMute.tsx
@@ -11,13 +11,7 @@ function LocalAudioMute() {
   const { muteLocalAudio, unmuteLocalAudio } = localBtnStyles || {}
   const { dispatch, localAudioTrack } = useContext(RtcContext)
   const local = useContext(LocalContext)
-  console.log('****mute****', muteLocalAudio, unmuteLocalAudio)
-  console.log(local.hasAudio === ToggleState.enabled)
-  console.log(
-    local.hasAudio === ToggleState.enabled
-      ? muteLocalAudio
-      : unmuteLocalAudio || muteLocalAudio
-  )
+
   return (
     <div>
       <BtnTemplate

--- a/src/Controls/Local/LocalAudioMute.tsx
+++ b/src/Controls/Local/LocalAudioMute.tsx
@@ -1,21 +1,25 @@
 import React, { useContext } from 'react'
-import RtcContext from '../../RtcContext'
-import BtnTemplate from '../BtnTemplate'
 import { LocalContext } from '../../LocalUserContext'
 import PropsContext, { ToggleState } from '../../PropsContext'
+import RtcContext from '../../RtcContext'
+import BtnTemplate from '../BtnTemplate'
 import muteAudio from './muteAudio'
 
 function LocalAudioMute() {
   const { styleProps, callbacks } = useContext(PropsContext)
   const { localBtnStyles } = styleProps || {}
-  const { muteLocalAudio } = localBtnStyles || {}
+  const { muteLocalAudio, unmuteLocalAudio } = localBtnStyles || {}
   const { dispatch, localAudioTrack } = useContext(RtcContext)
   const local = useContext(LocalContext)
 
   return (
     <div>
       <BtnTemplate
-        style={muteLocalAudio}
+        style={
+          local.hasAudio === ToggleState.enabled
+            ? muteLocalAudio
+            : unmuteLocalAudio || muteLocalAudio
+        }
         name={local.hasAudio === ToggleState.enabled ? 'mic' : 'micOff'}
         onClick={() =>
           localAudioTrack &&

--- a/src/Controls/Local/LocalAudioMute.tsx
+++ b/src/Controls/Local/LocalAudioMute.tsx
@@ -11,7 +11,13 @@ function LocalAudioMute() {
   const { muteLocalAudio, unmuteLocalAudio } = localBtnStyles || {}
   const { dispatch, localAudioTrack } = useContext(RtcContext)
   const local = useContext(LocalContext)
-
+  console.log('mute', muteLocalAudio, unmuteLocalAudio)
+  console.log(local.hasAudio === ToggleState.enabled)
+  console.log(
+    local.hasAudio === ToggleState.enabled
+      ? muteLocalAudio
+      : unmuteLocalAudio || muteLocalAudio
+  )
   return (
     <div>
       <BtnTemplate

--- a/src/Controls/Local/LocalVideoMute.tsx
+++ b/src/Controls/Local/LocalVideoMute.tsx
@@ -16,7 +16,7 @@ function LocalVideoMute() {
     <div>
       <BtnTemplate
         style={
-          local.hasAudio === ToggleState.enabled
+          local.hasVideo === ToggleState.enabled
             ? muteLocalVideo
             : unmuteLocalVideo || muteLocalVideo
         }

--- a/src/Controls/Local/LocalVideoMute.tsx
+++ b/src/Controls/Local/LocalVideoMute.tsx
@@ -1,21 +1,25 @@
 import React, { useContext } from 'react'
-import RtcContext from '../../RtcContext'
-import BtnTemplate from '../BtnTemplate'
 import { LocalContext } from '../../LocalUserContext'
 import PropsContext, { ToggleState } from '../../PropsContext'
+import RtcContext from '../../RtcContext'
+import BtnTemplate from '../BtnTemplate'
 import muteVideo from './muteVideo'
 
 function LocalVideoMute() {
   const { styleProps, callbacks } = useContext(PropsContext)
   const { localBtnStyles } = styleProps || {}
-  const { muteLocalVideo } = localBtnStyles || {}
+  const { muteLocalVideo, unmuteLocalVideo } = localBtnStyles || {}
   const { dispatch, localVideoTrack } = useContext(RtcContext)
   const local = useContext(LocalContext)
 
   return (
     <div>
       <BtnTemplate
-        style={muteLocalVideo}
+        style={
+          local.hasAudio === ToggleState.enabled
+            ? muteLocalVideo
+            : unmuteLocalVideo || muteLocalVideo
+        }
         name={
           local.hasVideo === ToggleState.enabled ? 'videocam' : 'videocamOff'
         }

--- a/src/Controls/LocalControls.tsx
+++ b/src/Controls/LocalControls.tsx
@@ -14,7 +14,6 @@ function LocalControls() {
     showTimer = false,
     localBtnWrapper = {}
   } = styleProps || {}
-  console.log('estoy en local controls')
   return (
     <div
       style={{

--- a/src/Controls/LocalControls.tsx
+++ b/src/Controls/LocalControls.tsx
@@ -14,7 +14,7 @@ function LocalControls() {
     showTimer = false,
     localBtnWrapper = {}
   } = styleProps || {}
-
+  console.log('estoy en local controls')
   return (
     <div
       style={{

--- a/src/PropsContext.tsx
+++ b/src/PropsContext.tsx
@@ -141,6 +141,10 @@ interface localBtnStylesInterface {
    * Style for the expand video button
    */
   fullScreen?: React.CSSProperties
+  /**
+   * Style for the un-expand video button
+   */
+  normalScreen?: React.CSSProperties
 }
 
 /**

--- a/src/PropsContext.tsx
+++ b/src/PropsContext.tsx
@@ -114,6 +114,10 @@ interface localBtnStylesInterface {
    */
   muteLocalAudio?: React.CSSProperties
   /**
+   * Style for the local unmute audio button
+   */
+  unmuteLocalAudio?: React.CSSProperties
+  /**
    * Style for the local screenshare button
    */
   screenshare?: React.CSSProperties
@@ -121,6 +125,10 @@ interface localBtnStylesInterface {
    * Style for the local mute video button
    */
   muteLocalVideo?: React.CSSProperties
+  /**
+   * Style for the local unmute video button
+   */
+  unmuteLocalVideo?: React.CSSProperties
   /**
    * Style for the switch camera button
    */


### PR DESCRIPTION
Including more style props to toggle buttons. If second style prop is no added, first one is used to both toggle statuses.

New props included are:
`unmuteLocalVideo` (paired with `muteLocalVideo`)
`unmuteLocalAudio` (paired with `muteLocalAudio`)
`normalScreen` (paired with `fullScreen`)