### PR TITLE
Fix: Fixing error publishing tracks before joining.

### DIFF
--- a/src/RTCConfigure.tsx
+++ b/src/RTCConfigure.tsx
@@ -319,16 +319,25 @@ const RtcConfigure: React.FC<PropsWithChildren<Partial<RtcPropsInterface>>> = (
       // handle publish fail if track is not enabled
       if (localAudioTrack?.enabled && channelJoined) {
         if (!localAudioTrackHasPublished) {
-          await client.publish([localAudioTrack]).then(() => {
-            localAudioTrackHasPublished = true
-          })
+          // await client.publish([localAudioTrack]).then(() => {
+
+          client
+            .publish([localAudioTrack])
+            .then(() => {
+              localAudioTrackHasPublished = true
+            })
+            .catch((e) => console.error('ERROR EN EL PUBLISH 1', e))
         }
       }
       if (localVideoTrack?.enabled && channelJoined) {
         if (!localVideoTrackHasPublished) {
-          await client.publish([localVideoTrack]).then(() => {
-            localVideoTrackHasPublished = true
-          })
+          // await
+          client
+            .publish([localVideoTrack])
+            .then(() => {
+              localVideoTrackHasPublished = true
+            })
+            .catch((e) => console.error('ERROR EN EL PUBLISH 2', e))
         }
       }
     }

--- a/src/RTCConfigure.tsx
+++ b/src/RTCConfigure.tsx
@@ -311,6 +311,8 @@ const RtcConfigure: React.FC<PropsWithChildren<Partial<RtcPropsInterface>>> = (
   // publish local stream
   useEffect(() => {
     async function publish() {
+      console.log('%c****inside PUBLISH FUNCTION***', 'color: blue')
+
       if (rtcProps.enableDualStream) {
         await client.enableDualStream()
       }
@@ -330,7 +332,6 @@ const RtcConfigure: React.FC<PropsWithChildren<Partial<RtcPropsInterface>>> = (
         }
       }
     }
-    console.log('Publish', localVideoTrack, localAudioTrack, callActive)
     if (callActive && channelJoined) {
       console.log('%c****inside publish if***', 'color: green')
       publish()

--- a/src/RTCConfigure.tsx
+++ b/src/RTCConfigure.tsx
@@ -310,7 +310,7 @@ const RtcConfigure: React.FC<PropsWithChildren<Partial<RtcPropsInterface>>> = (
 
   // publish local stream
   useEffect(() => {
-    console.log('uid', uid, uid.current)
+    console.log('uid', uid, uid.current, rtcProps.uid)
     async function publish() {
       console.log('%c****inside PUBLISH FUNCTION***', 'color: blue')
 
@@ -351,7 +351,8 @@ const RtcConfigure: React.FC<PropsWithChildren<Partial<RtcPropsInterface>>> = (
     localVideoTrack?.enabled,
     localAudioTrack?.enabled,
     channelJoined,
-    uid
+    uid,
+    rtcProps.uid
   ])
 
   // update local state if tracks are not null

--- a/src/RTCConfigure.tsx
+++ b/src/RTCConfigure.tsx
@@ -264,7 +264,6 @@ const RtcConfigure: React.FC<PropsWithChildren<Partial<RtcPropsInterface>>> = (
             const data = await res.json()
             const token = data.rtcToken
             uid.current = await client.join(appId, channel, token, userUid || 0)
-            console.log('UID CURRENT', uid.current)
           } catch (e) {
             console.log(e)
           }
@@ -276,7 +275,6 @@ const RtcConfigure: React.FC<PropsWithChildren<Partial<RtcPropsInterface>>> = (
               token || null,
               userUid || 0
             )
-            console.log('UID CURRENT 2', uid.current)
           } catch (e) {
             console.error(e)
             callbacks?.ErrorJoining && callbacks.ErrorJoining()
@@ -312,6 +310,7 @@ const RtcConfigure: React.FC<PropsWithChildren<Partial<RtcPropsInterface>>> = (
 
   // publish local stream
   useEffect(() => {
+    console.log('uid', uid, uid.current)
     async function publish() {
       console.log('%c****inside PUBLISH FUNCTION***', 'color: blue')
 
@@ -351,7 +350,8 @@ const RtcConfigure: React.FC<PropsWithChildren<Partial<RtcPropsInterface>>> = (
     callActive,
     localVideoTrack?.enabled,
     localAudioTrack?.enabled,
-    channelJoined
+    channelJoined,
+    uid
   ])
 
   // update local state if tracks are not null

--- a/src/RTCConfigure.tsx
+++ b/src/RTCConfigure.tsx
@@ -310,40 +310,27 @@ const RtcConfigure: React.FC<PropsWithChildren<Partial<RtcPropsInterface>>> = (
 
   // publish local stream
   useEffect(() => {
-    console.log('uid', uid, uid.current, rtcProps.uid)
     async function publish() {
-      console.log('%c****inside PUBLISH FUNCTION***', 'color: blue')
-
       if (rtcProps.enableDualStream) {
         await client.enableDualStream()
       }
       // handle publish fail if track is not enabled
       if (localAudioTrack?.enabled && channelJoined) {
         if (!localAudioTrackHasPublished) {
-          // await client.publish([localAudioTrack]).then(() => {
-
-          client
-            .publish([localAudioTrack])
-            .then(() => {
-              localAudioTrackHasPublished = true
-            })
-            .catch((e) => console.error('ERROR EN EL PUBLISH 1', e))
+          await client.publish([localAudioTrack]).then(() => {
+            localAudioTrackHasPublished = true
+          })
         }
       }
       if (localVideoTrack?.enabled && channelJoined) {
         if (!localVideoTrackHasPublished) {
-          // await
-          client
-            .publish([localVideoTrack])
-            .then(() => {
-              localVideoTrackHasPublished = true
-            })
-            .catch((e) => console.error('ERROR EN EL PUBLISH 2', e))
+          await client.publish([localVideoTrack]).then(() => {
+            localVideoTrackHasPublished = true
+          })
         }
       }
     }
-    if (callActive && channelJoined) {
-      console.log('%c****inside publish if***', 'color: green')
+    if (callActive && channelJoined && uid?.current !== undefined) {
       publish()
     }
   }, [

--- a/src/RTCConfigure.tsx
+++ b/src/RTCConfigure.tsx
@@ -331,7 +331,8 @@ const RtcConfigure: React.FC<PropsWithChildren<Partial<RtcPropsInterface>>> = (
       }
     }
     console.log('Publish', localVideoTrack, localAudioTrack, callActive)
-    if (callActive) {
+    if (callActive && channelJoined) {
+      console.log('%c****inside publish if***', 'color: green')
       publish()
     }
   }, [

--- a/src/RTCConfigure.tsx
+++ b/src/RTCConfigure.tsx
@@ -351,8 +351,7 @@ const RtcConfigure: React.FC<PropsWithChildren<Partial<RtcPropsInterface>>> = (
     localVideoTrack?.enabled,
     localAudioTrack?.enabled,
     channelJoined,
-    uid,
-    rtcProps.uid
+    uid?.current
   ])
 
   // update local state if tracks are not null

--- a/src/RTCConfigure.tsx
+++ b/src/RTCConfigure.tsx
@@ -264,6 +264,7 @@ const RtcConfigure: React.FC<PropsWithChildren<Partial<RtcPropsInterface>>> = (
             const data = await res.json()
             const token = data.rtcToken
             uid.current = await client.join(appId, channel, token, userUid || 0)
+            console.log('UID CURRENT', uid.current)
           } catch (e) {
             console.log(e)
           }
@@ -275,6 +276,7 @@ const RtcConfigure: React.FC<PropsWithChildren<Partial<RtcPropsInterface>>> = (
               token || null,
               userUid || 0
             )
+            console.log('UID CURRENT 2', uid.current)
           } catch (e) {
             console.error(e)
             callbacks?.ErrorJoining && callbacks.ErrorJoining()


### PR DESCRIPTION
This error was found testing video calls in different devices. When first person start calling, his tracks are visible in devices, but an error publish them is happening, because agora UI kit is trying to publish them before joining to video call. 
The other person in call only can receive other tracks if first one mute their phone or video and updating status, his tracks were republished.

This PR fix this error and only publish the tracks after finish joining call.