### PR TITLE
chore(): updating react dependency for new react versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agora-video-uikit-react",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "A React UIKit for the Agora Web SDK (based on EkaanshArora project)",
   "author": "elenitaex5 <elena.martincastillo@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "docs": "typedoc src"
   },
   "peerDependencies": {
-    "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+    "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@types/estree": "^1.0.0",


### PR DESCRIPTION
This pull request updates the `react` peer dependency version range in `package.json` to include support for React 19 and drop support for React 16.

Dependency updates:

* Updated the `react` peer dependency version range to `^17.0.0 || ^18.0.0 || ^19.0.0` in `package.json`, removing support for React 16 and adding support for React 19.